### PR TITLE
ML: Don't use `MPI_COMM_WORLD` in `MLAPI_Workspace`

### DIFF
--- a/packages/ml/src/Comm/ml_comm.h
+++ b/packages/ml/src/Comm/ml_comm.h
@@ -25,6 +25,7 @@
 #ifdef ML_MPI
 #include <mpi.h>
 #define USR_COMM MPI_Comm
+#define USR_MPI_COMM_WORLD MPI_COMM_WORLD
 #define USR_REQ  MPI_Request
 
 #define USR_ERRHANDLER MPI_Errhandler
@@ -56,9 +57,10 @@ typedef struct ml_DblLoc_struct {
 
 #endif /* ifdef ML_CATCH_MPI_ERRORS_IN_DEBUGGER */
 
-#else
+#else /* ifdef ML_MPI */
 
 #define USR_COMM int
+#define USR_MPI_COMM_WORLD 0
 #define USR_REQ  int
 
 #define USR_ERRHANDLER int

--- a/packages/ml/src/MLAPI/MLAPI_Workspace.cpp
+++ b/packages/ml/src/MLAPI/MLAPI_Workspace.cpp
@@ -82,12 +82,12 @@ void SetPrintLevel(int Level)
 }
 
 // ======================================================================
-void Init()
+void Init(USR_COMM comm)
 {
-  if (ML_Comm_ == 0) ML_Comm_Create(&ML_Comm_);
+  if (ML_Comm_ == 0) ML_Comm_Create2(&ML_Comm_, comm);
   if (Epetra_Comm_ == 0) {
 #ifdef HAVE_MPI
-    Epetra_Comm_ = new Epetra_MpiComm(MPI_COMM_WORLD);
+    Epetra_Comm_ = new Epetra_MpiComm(comm);
 #else
     Epetra_Comm_ = new Epetra_SerialComm;
 #endif

--- a/packages/ml/src/MLAPI/MLAPI_Workspace.h
+++ b/packages/ml/src/MLAPI/MLAPI_Workspace.h
@@ -60,7 +60,7 @@ int GetPrintLevel();
 void SetPrintLevel(int Level);
 
 //! Initialize the MLAPI workspace.
-void Init();
+void Init(USR_COMM comm = USR_MPI_COMM_WORLD);
 
 //! Destroys the MLAPI workspace.
 void Finalize();


### PR DESCRIPTION
Fixes #56 