### PR TITLE
#94: Remove use of MPI_COMM_WORLD in Krino package

### DIFF
--- a/packages/krino/krino/krino_lib/Akri_BoundingBoxMesh.hpp
+++ b/packages/krino/krino/krino_lib/Akri_BoundingBoxMesh.hpp
@@ -10,6 +10,7 @@
 #define Akri_BoundingBoxMesh_h
 
 #include <Akri_BoundingBox.hpp>
+#include <Akri_DefaultComm.hpp>
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 #include <array>
@@ -75,7 +76,7 @@ public:
 public:
   BoundingBoxMesh(stk::topology element_topology, const std::vector<std::string>& rank_names = std::vector<std::string>());
   void set_domain(const BoundingBoxType & mesh_bbox, const double mesh_size, const int pad_cells = 0);
-  void populate_mesh(stk::ParallelMachine pm = MPI_COMM_WORLD, const stk::mesh::BulkData::AutomaticAuraOption auto_aura_option = stk::mesh::BulkData::AUTO_AURA);
+  void populate_mesh(stk::ParallelMachine pm = get_global_comm(), const stk::mesh::BulkData::AutomaticAuraOption auto_aura_option = stk::mesh::BulkData::AUTO_AURA);
   stk::mesh::MetaData & meta_data() { STK_ThrowAssert( nullptr != m_meta.get() ) ; return *m_meta; }
   stk::mesh::BulkData & bulk_data() { STK_ThrowAssert( nullptr != m_mesh.get() ) ; return *m_mesh; }
   const stk::mesh::MetaData & meta_data() const { STK_ThrowAssert( nullptr != m_meta.get() ) ; return *m_meta; }

--- a/packages/krino/krino/krino_lib/Akri_BoundingBoxMesh.hpp
+++ b/packages/krino/krino/krino_lib/Akri_BoundingBoxMesh.hpp
@@ -10,7 +10,7 @@
 #define Akri_BoundingBoxMesh_h
 
 #include <Akri_BoundingBox.hpp>
-#include <Akri_DefaultComm.hpp>
+#include <Akri_GlobalComm.hpp>
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 #include <array>

--- a/packages/krino/krino/krino_lib/Akri_DefaultComm.hpp
+++ b/packages/krino/krino/krino_lib/Akri_DefaultComm.hpp
@@ -1,0 +1,32 @@
+// Copyright 2002 - 2008, 2010, 2011 National Technology Engineering
+// Solutions of Sandia, LLC (NTESS). Under the terms of Contract
+// DE-NA0003525 with NTESS, the U.S. Government retains certain rights
+// in this software.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#ifndef KRINO_KRINO_KRINO_LIB_AKRI_DEFAULT_COMM_HPP_
+#define KRINO_KRINO_KRINO_LIB_AKRI_DEFAULT_COMM_HPP_
+
+#include <mpi.h>
+#include <mutex>
+
+namespace krino {
+
+static std::mutex mpi_mutex;
+static MPI_Comm Global_MPI_Comm = MPI_COMM_WORLD;
+
+inline void initialize_global_comm(MPI_Comm comm) {
+    std::lock_guard<std::mutex> guard(mpi_mutex);
+    Global_MPI_Comm = comm;
+}
+
+inline MPI_Comm get_global_comm() {
+    std::lock_guard<std::mutex> guard(mpi_mutex);
+    return Global_MPI_Comm;
+}
+
+}
+
+#endif /* KRINO_KRINO_KRINO_LIB_AKRI_DEFAULT_COMM_HPP_ */

--- a/packages/krino/krino/krino_lib/Akri_GlobalComm.hpp
+++ b/packages/krino/krino/krino_lib/Akri_GlobalComm.hpp
@@ -6,8 +6,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#ifndef KRINO_KRINO_KRINO_LIB_AKRI_DEFAULT_COMM_HPP_
-#define KRINO_KRINO_KRINO_LIB_AKRI_DEFAULT_COMM_HPP_
+#ifndef KRINO_KRINO_KRINO_LIB_AKRI_GLOBAL_COMM_HPP_
+#define KRINO_KRINO_KRINO_LIB_AKRI_GLOBAL_COMM_HPP_
 
 #include <mpi.h>
 #include <mutex>
@@ -29,4 +29,4 @@ inline MPI_Comm get_global_comm() {
 
 }
 
-#endif /* KRINO_KRINO_KRINO_LIB_AKRI_DEFAULT_COMM_HPP_ */
+#endif /* KRINO_KRINO_KRINO_LIB_AKRI_GLOBAL_COMM_HPP_ */

--- a/packages/krino/krino/region/Akri_Startup.cpp
+++ b/packages/krino/krino/region/Akri_Startup.cpp
@@ -7,7 +7,7 @@
 // license that can be found in the LICENSE file.
 
 #include <Akri_Startup.hpp>
-
+#include <Akri_DefaultComm.hpp>
 #include <Akri_DiagWriter.hpp>
 #include <Akri_RegisterProduct.hpp>
 
@@ -84,7 +84,7 @@ Startup::Startup(int argc, char ** argv)
     throw std::runtime_error("MPI_Init failed");
   }
 
-  stk::EnvData::instance().m_parallelComm = MPI_COMM_WORLD;
+  stk::EnvData::instance().m_parallelComm = get_global_comm();
   MPI_Comm_size(stk::EnvData::parallel_comm(), &stk::EnvData::instance().m_parallelSize);
   MPI_Comm_rank(stk::EnvData::parallel_comm(), &stk::EnvData::instance().m_parallelRank);
 

--- a/packages/krino/krino/region/Akri_Startup.cpp
+++ b/packages/krino/krino/region/Akri_Startup.cpp
@@ -7,7 +7,7 @@
 // license that can be found in the LICENSE file.
 
 #include <Akri_Startup.hpp>
-#include <Akri_DefaultComm.hpp>
+#include <Akri_GlobalComm.hpp>
 #include <Akri_DiagWriter.hpp>
 #include <Akri_RegisterProduct.hpp>
 


### PR DESCRIPTION
Close #94 