### PR TITLE
#205: Belos: clean MINRES Tpetra test_minres_diag test

### DIFF
--- a/packages/belos/tpetra/test/MINRES/test_minres_hb.cpp
+++ b/packages/belos/tpetra/test/MINRES/test_minres_hb.cpp
@@ -72,8 +72,7 @@ int run(int argc, char *argv[]) {
   using MVT = typename Belos::MultiVecTraits<ST,MV>;
   using OPT = typename Belos::OperatorTraits<ST,MV,OP>;
 
-  using tcrsmatrix_t = Tpetra::CrsMatrix<ST,LO,GO,NT>;
-  using tmultivector_t = Tpetra::MultiVector<ST,LO,GO,NT>;
+  using tcrsmatrix_t = typename Tpetra::CrsMatrix<ST,LO,GO,NT>;
 
   using Teuchos::inOutArg;
   using Teuchos::ParameterList;
@@ -130,7 +129,7 @@ int run(int argc, char *argv[]) {
     //
     // *****Construct initial guess and random right-hand-sides *****
     //
-    RCP<tmultivector_t> B, X;    
+    RCP<MV> B, X;    
     X = rcp( new MV(rowMap, numRHS) );
     MVT::MvRandom( *X );
     B = rcp( new MV(rowMap, numRHS ) );

--- a/packages/belos/tpetra/test/MINRES/test_pminres_hb.cpp
+++ b/packages/belos/tpetra/test/MINRES/test_pminres_hb.cpp
@@ -74,8 +74,7 @@ int run(int argc, char *argv[]){
   using MVT = typename Belos::MultiVecTraits<ST,MV>;
   using OPT = typename Belos::OperatorTraits<ST,MV,OP>;
 
-  using tcrsmatrix_t = Tpetra::CrsMatrix<ST,LO,GO,NT>;
-  using tmultivector_t = Tpetra::MultiVector<ST,LO,GO,NT>;
+  using tcrsmatrix_t = typename Tpetra::CrsMatrix<ST,LO,GO,NT>;
 
   using Teuchos::ParameterList;
   using Teuchos::RCP;
@@ -128,7 +127,7 @@ int run(int argc, char *argv[]){
     RCP<const Tpetra::Map<> > map = A->getDomainMap();
 
     // Create initial vectors
-    RCP<tmultivector_t> X, B;
+    RCP<MV> X, B;
     X = rcp(new MV(map, numrhs));
     MVT::MvRandom( *X );
     B = rcp(new MV(map, numrhs));
@@ -214,17 +213,17 @@ int run(int argc, char *argv[]){
     // Compute actual residuals.
     //
     bool badRes = false;
-    std::vector<MT> actual_resids( numrhs );
-    std::vector<MT> rhs_norm( numrhs );
+    std::vector<MT> actualResids( numrhs );
+    std::vector<MT> rhsNorm( numrhs );
     MV resid(map, numrhs);
     OPT::Apply( *A, *X, resid );
     MVT::MvAddMv( -1.0, resid, 1.0, *B, resid );
-    MVT::MvNorm( resid, actual_resids );
-    MVT::MvNorm( *B, rhs_norm );
+    MVT::MvNorm( resid, actualResids );
+    MVT::MvNorm( *B, rhsNorm );
     if (proc_verbose) {
       std::cout<< "---------- Actual Residuals (normalized) ----------"<<std::endl<<std::endl;
       for ( int i=0; i<numrhs; i++) {
-        double actRes = actual_resids[i]/rhs_norm[i];
+        double actRes = actualResids[i]/rhsNorm[i];
         std::cout<<"Problem "<<i<<" : \t"<< actRes <<std::endl;
         if (actRes > tol) badRes = true;
       }


### PR DESCRIPTION
Fixes #205 

PR to Trilinos: https://github.com/trilinos/Trilinos/pull/12322 (including #70, #177, #206)

This solves also other problems related to the `test_minres_diag` Tpetra test

This PR comes in addition to #70  and #177  to include the Belos Tpetra MINRES tests into Trilinos.

This PR provides the following to the `test_minres_diag` Tpetra test in Belos:
- Reorder includes
- Make class names CamelCase (mainly operator classes)
- Pass scalar type using C++ templates to the classes instead of explicit `double` type
- Use Teuchos version `Teuchos::reduceAll` istead of MPI one (MPI_REDUCE_ALL)
- Fixes a bug occuring when applying a DiagonalOperator2 operator (was commented in the Tpetra version until this PR)